### PR TITLE
用deepseek加了广告屏蔽

### DIFF
--- a/hook/build.gradle
+++ b/hook/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "cc.aoeiuv020.hookpicacg"
         minSdk 26
         targetSdk 32
-        versionCode 1
-        versionName "2.2.1.3.3.4-5"
+        versionCode 2
+        versionName "2.2.1.3.3.4-6"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/hook/src/main/java/cc/aoeiuv020/hookpicacg/MainHook.java
+++ b/hook/src/main/java/cc/aoeiuv020/hookpicacg/MainHook.java
@@ -44,7 +44,7 @@ public class MainHook implements IXposedHookLoadPackage {
         // 拦截广告域名请求（OkHttp3）
         hookOkHttp(lpparam);
 
-        // 原始的各种Hook方法保持不变
+        // 原始Hook方法保持不变
         XposedHelpers.findAndHookMethod(
                 dialogClass,
                 "showAnnouncementAlertDialog",
@@ -60,9 +60,104 @@ public class MainHook implements IXposedHookLoadPackage {
                         param.setResult(null);
                     }
                 });
-        
-        // ... 保持其他原有的Hook方法不变 ...
-        // 注意：这里省略了原有代码中的其他Hook方法，实际代码中需保留
+        XposedHelpers.findAndHookMethod(
+                "com.picacomic.fregata.utils.views.PopupWebview",
+                lpparam.classLoader,
+                "init",
+                Context.class,
+                new XC_MethodHook() {
+                    @Override
+                    protected void beforeHookedMethod(MethodHookParam param) {
+                        XposedBridge.log("beforeHookedMethod: PopupWebview.init(Context)");
+                        param.setResult(null);
+                    }
+                });
+        XposedHelpers.findAndHookMethod(
+                "com.picacomic.fregata.utils.views.BannerWebview",
+                lpparam.classLoader,
+                "init",
+                Context.class,
+                new XC_MethodHook() {
+                    @Override
+                    protected void beforeHookedMethod(MethodHookParam param) {
+                        XposedBridge.log("beforeHookedMethod: BannerWebview.init(Context)");
+                        param.setResult(null);
+                    }
+                });
+        XposedHelpers.findAndHookMethod(
+                "com.picacomic.fregata.activities.MainActivity",
+                lpparam.classLoader,
+                "onCreate",
+                Bundle.class,
+                new XC_MethodHook() {
+                    @Override
+                    protected void afterHookedMethod(MethodHookParam param) {
+                        XposedBridge.log("afterHookedMethod: MainActivity.onCreate(Bundle)");
+                        View[] buttons_tabbar = (View[]) XposedHelpers.getObjectField(param.thisObject, "buttons_tabbar");
+                        buttons_tabbar[2].setVisibility(View.GONE);
+                        Activity activity = (Activity) param.thisObject;
+                        ViewGroup root = (ViewGroup) ((ViewGroup) (activity.findViewById(android.R.id.content))).getChildAt(0);
+                        for (int i = root.getChildCount() - 1; i >= 0; i--) {
+                            View child = root.getChildAt(i);
+                            if (TextUtils.equals("com.picacomic.fregata.utils.views.BannerWebview", child.getClass().getName())
+                                    || TextUtils.equals("com.picacomic.fregata.utils.views.PopupWebview", child.getClass().getName())) {
+                                root.removeViewAt(i);
+                            }
+                        }
+                    }
+
+                });
+        XposedHelpers.findAndHookMethod(
+                "com.picacomic.fregata.fragments.HomeFragment",
+                lpparam.classLoader,
+                "onCreateView",
+                LayoutInflater.class,
+                ViewGroup.class,
+                Bundle.class,
+                new XC_MethodHook() {
+                    @Override
+                    protected void afterHookedMethod(MethodHookParam param) {
+                        XposedBridge.log("afterHookedMethod: HomeFragment.onCreateView");
+                        View viewPager_banner = (View) XposedHelpers.getObjectField(param.thisObject, "viewPager_banner");
+                        ((View) (viewPager_banner.getParent())).setVisibility(View.GONE);
+                        View linearLayout_announcements = (View) XposedHelpers.getObjectField(param.thisObject, "linearLayout_announcements");
+                        linearLayout_announcements.setVisibility(View.GONE);
+                    }
+                });
+        XposedHelpers.findAndHookMethod(
+                "com.picacomic.fregata.adapters.ComicPageRecyclerViewAdapter",
+                lpparam.classLoader,
+                "onCreateViewHolder",
+                ViewGroup.class,
+                int.class,
+                new XC_MethodHook() {
+                    @Override
+                    protected void afterHookedMethod(MethodHookParam param) {
+                        XposedBridge.log("afterHookedMethod: ComicPageRecyclerViewAdapter.onCreateViewHolder");
+                        Object result = param.getResult();
+                        if (!TextUtils.equals(result.getClass().getName(), "com.picacomic.fregata.holders.AdvertisementListViewHolder")) {
+                            return;
+                        }
+                        View webView_ads = (View) XposedHelpers.getObjectField(result, "itemView");
+                        webView_ads.setVisibility(View.GONE);
+                        Object lp = XposedHelpers.newInstance(XposedHelpers.findClass("android.support.v7.widget.RecyclerView$LayoutParams", lpparam.classLoader), 0, 0);
+                        webView_ads.setLayoutParams((ViewGroup.LayoutParams) lp);
+                    }
+                });
+        XposedHelpers.findAndHookMethod("com.picacomic.fregata.adapters.ComicListRecyclerViewAdapter", lpparam.classLoader, "onBindViewHolder", XposedHelpers.findClass("android.support.v7.widget.RecyclerView$ViewHolder", lpparam.classLoader), int.class, new XC_MethodHook() {
+            @Override
+            protected void beforeHookedMethod(MethodHookParam param) {
+                Object viewHolder = param.args[0];
+                if (viewHolder.getClass().getSimpleName().equals("AdvertisementListViewHolder")) {
+                    param.setResult(null);
+                    View itemView = (View) XposedHelpers.getObjectField(viewHolder, "itemView");
+                    ViewGroup.LayoutParams lp = (ViewGroup.LayoutParams) itemView.getLayoutParams();
+                    // 完全隐藏会影响分页加载的逻辑，所以保留一点，
+                    lp.height = 1;
+                    itemView.setLayoutParams(lp);
+                }
+            }
+        });
     }
 
     /**
@@ -98,7 +193,7 @@ public class MainHook implements IXposedHookLoadPackage {
                             protected void beforeHookedMethod(MethodHookParam param) {
                                 Object request = param.args[1];
                                 String url = (String) XposedHelpers.callMethod(request, "getUrl");
-                                if (isAdUrl(url.toString())) {
+                                if (isAdUrl(url)) {
                                     param.setResult(createTransparentGifResponse());
                                 }
                             }
@@ -114,57 +209,67 @@ public class MainHook implements IXposedHookLoadPackage {
      */
     private void hookOkHttp(XC_LoadPackage.LoadPackageParam lpparam) {
         try {
-            final Class<?> callClass = XposedHelpers.findClass("okhttp3.Call", lpparam.classLoader);
-            final Class<?> requestClass = XposedHelpers.findClass("okhttp3.Request", lpparam.classLoader);
+            final Class<?> callClass = XposedHelpers.findClassIfExists("okhttp3.Call", lpparam.classLoader);
+            if (callClass == null) return;
 
+            final Class<?> requestClass = XposedHelpers.findClass("okhttp3.Request", lpparam.classLoader);
+            final Class<?> interceptorClass = XposedHelpers.findClass("okhttp3.Interceptor", lpparam.classLoader);
+            final Class<?> chainClass = XposedHelpers.findClass("okhttp3.Interceptor$Chain", lpparam.classLoader);
+
+            // Hook Interceptor.Chain.proceed()
             XposedHelpers.findAndHookMethod(
-                    "okhttp3.internal.http.RealInterceptorChain",
-                    lpparam.classLoader,
+                    chainClass,
                     "proceed",
                     requestClass,
                     new XC_MethodHook() {
                         @Override
                         protected void beforeHookedMethod(MethodHookParam param) {
                             Object request = param.args[0];
-                            String url = (String) XposedHelpers.callMethod(
-                                    XposedHelpers.callMethod(request, "url"),
-                                    "toString");
+                            Object url = XposedHelpers.callMethod(request, "url");
+                            String urlString = (String) XposedHelpers.callMethod(url, "toString");
 
-                            if (isAdUrl(url)) {
-                                // 创建伪造的透明图片响应
-                                Class<?> responseClass = XposedHelpers.findClass("okhttp3.Response", lpparam.classLoader);
-                                Class<?> responseBodyClass = XposedHelpers.findClass("okhttp3.ResponseBody", lpparam.classLoader);
-                                Class<?> mediaTypeClass = XposedHelpers.findClass("okhttp3.MediaType", lpparam.classLoader);
-
-                                // 创建MediaType
-                                Object mediaType = XposedHelpers.callStaticMethod(
-                                        mediaTypeClass,
-                                        "parse",
-                                        "image/gif");
-
-                                // 创建ResponseBody
-                                Object responseBody = XposedHelpers.newInstance(
-                                        responseBodyClass,
-                                        mediaType,
-                                        TRANSPARENT_GIF);
-
-                                // 构建伪造响应
-                                Object response = XposedHelpers.newInstance(
-                                        responseClass,
-                                        request,
-                                        200,  // HTTP 200 OK
-                                        "OK",
-                                        null,  // Handshake
-                                        null,  // Headers
-                                        responseBody,
-                                        null,  // CacheControl
-                                        null,  // SentRequestAtMillis
-                                        null,  // ReceivedResponseAtMillis
-                                        null,  // Exchange
-                                        null   // PriorResponse
-                                );
-
-                                param.setResult(response);
+                            if (isAdUrl(urlString)) {
+                                try {
+                                    // 创建伪造的透明图片响应
+                                    Class<?> responseClass = XposedHelpers.findClass("okhttp3.Response", lpparam.classLoader);
+                                    Class<?> responseBodyClass = XposedHelpers.findClass("okhttp3.ResponseBody", lpparam.classLoader);
+                                    Class<?> mediaTypeClass = XposedHelpers.findClass("okhttp3.MediaType", lpparam.classLoader);
+                                    
+                                    // 创建MediaType
+                                    Object mediaType = XposedHelpers.callStaticMethod(
+                                            mediaTypeClass,
+                                            "parse",
+                                            "image/gif");
+                                    
+                                    // 创建ResponseBody
+                                    Object responseBody = XposedHelpers.newInstance(
+                                            responseBodyClass,
+                                            mediaType,
+                                            TRANSPARENT_GIF);
+                                    
+                                    // 构建伪造响应
+                                    Object response = XposedHelpers.callStaticMethod(
+                                            responseClass,
+                                            "newBuilder",
+                                            request,
+                                            200,  // HTTP 200 OK
+                                            "OK",
+                                            null,  // Handshake
+                                            null,  // Headers
+                                            responseBody,
+                                            null,  // CacheControl
+                                            null,  // SentRequestAtMillis
+                                            null,  // ReceivedResponseAtMillis
+                                            null,  // Exchange
+                                            null   // PriorResponse
+                                    );
+                                    
+                                    // 获取最终响应对象
+                                    Object finalResponse = XposedHelpers.callMethod(response, "build");
+                                    param.setResult(finalResponse);
+                                } catch (Throwable t) {
+                                    XposedBridge.log("Error creating fake response: " + t);
+                                }
                             }
                         }
                     });

--- a/hook/src/main/java/cc/aoeiuv020/hookpicacg/MainHook.java
+++ b/hook/src/main/java/cc/aoeiuv020/hookpicacg/MainHook.java
@@ -4,9 +4,19 @@ import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
 import android.text.TextUtils;
+import android.util.Base64;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.webkit.WebResourceResponse;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
 
 import de.robv.android.xposed.IXposedHookLoadPackage;
 import de.robv.android.xposed.XC_MethodHook;
@@ -14,15 +24,27 @@ import de.robv.android.xposed.XposedBridge;
 import de.robv.android.xposed.XposedHelpers;
 import de.robv.android.xposed.callbacks.XC_LoadPackage;
 
-@SuppressWarnings("RedundantThrows")
+@SuppressWarnings({"RedundantThrows", "unused"})
 public class MainHook implements IXposedHookLoadPackage {
+    // 1x1 透明 GIF 图片的 Base64 编码
+    private static final String TRANSPARENT_GIF_BASE64 = "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
+    private static final byte[] TRANSPARENT_GIF = Base64.decode(TRANSPARENT_GIF_BASE64, Base64.DEFAULT);
+
     @Override
     public void handleLoadPackage(XC_LoadPackage.LoadPackageParam lpparam) throws Throwable {
-        XposedBridge.log("handleLoadPackage: " + lpparam.processName + ", " + lpparam.processName);
+        XposedBridge.log("handleLoadPackage: " + lpparam.processName);
         Class<?> dialogClass = XposedHelpers.findClassIfExists("com.picacomic.fregata.utils.views.AlertDialogCenter", lpparam.classLoader);
         if (dialogClass == null) {
             return;
         }
+
+        // 拦截广告域名请求（WebView）
+        hookWebViewClient(lpparam);
+        
+        // 拦截广告域名请求（OkHttp3）
+        hookOkHttp(lpparam);
+
+        // 原始的各种Hook方法保持不变
         XposedHelpers.findAndHookMethod(
                 dialogClass,
                 "showAnnouncementAlertDialog",
@@ -34,107 +56,135 @@ public class MainHook implements IXposedHookLoadPackage {
                 View.OnClickListener.class,
                 new XC_MethodHook() {
                     @Override
-                    protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
+                    protected void beforeHookedMethod(MethodHookParam param) {
                         param.setResult(null);
                     }
                 });
-        XposedHelpers.findAndHookMethod(
-                "com.picacomic.fregata.utils.views.PopupWebview",
-                lpparam.classLoader,
-                "init",
-                Context.class,
-                new XC_MethodHook() {
-                    @Override
-                    protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
-                        XposedBridge.log("beforeHookedMethod: PopupWebview.init(Context)");
-                        param.setResult(null);
-                    }
-                });
-        XposedHelpers.findAndHookMethod(
-                "com.picacomic.fregata.utils.views.BannerWebview",
-                lpparam.classLoader,
-                "init",
-                Context.class,
-                new XC_MethodHook() {
-                    @Override
-                    protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
-                        XposedBridge.log("beforeHookedMethod: BannerWebview.init(Context)");
-                        param.setResult(null);
-                    }
-                });
-        XposedHelpers.findAndHookMethod(
-                "com.picacomic.fregata.activities.MainActivity",
-                lpparam.classLoader,
-                "onCreate",
-                Bundle.class,
-                new XC_MethodHook() {
-                    @Override
-                    protected void afterHookedMethod(MethodHookParam param) throws Throwable {
-                        XposedBridge.log("afterHookedMethod: MainActivity.onCreate(Bundle)");
-                        View[] buttons_tabbar = (View[]) XposedHelpers.getObjectField(param.thisObject, "buttons_tabbar");
-                        buttons_tabbar[2].setVisibility(View.GONE);
-                        Activity activity = (Activity) param.thisObject;
-                        ViewGroup root = (ViewGroup) ((ViewGroup) (activity.findViewById(android.R.id.content))).getChildAt(0);
-                        for (int i = root.getChildCount() - 1; i >= 0; i--) {
-                            View child = root.getChildAt(i);
-                            if (TextUtils.equals("com.picacomic.fregata.utils.views.BannerWebview", child.getClass().getName())
-                                    || TextUtils.equals("com.picacomic.fregata.utils.views.PopupWebview", child.getClass().getName())) {
-                                root.removeViewAt(i);
+        
+        // ... 保持其他原有的Hook方法不变 ...
+        // 注意：这里省略了原有代码中的其他Hook方法，实际代码中需保留
+    }
+
+    /**
+     * 拦截WebView中的广告请求
+     */
+    private void hookWebViewClient(XC_LoadPackage.LoadPackageParam lpparam) {
+        try {
+            // 拦截旧版WebViewClient (String url)
+            XposedHelpers.findAndHookMethod(
+                    WebViewClient.class,
+                    "shouldInterceptRequest",
+                    WebView.class,
+                    String.class,
+                    new XC_MethodHook() {
+                        @Override
+                        protected void beforeHookedMethod(MethodHookParam param) {
+                            String url = (String) param.args[1];
+                            if (isAdUrl(url)) {
+                                param.setResult(createTransparentGifResponse());
                             }
                         }
-                    }
+                    });
 
-                });
-        XposedHelpers.findAndHookMethod(
-                "com.picacomic.fregata.fragments.HomeFragment",
-                lpparam.classLoader,
-                "onCreateView",
-                LayoutInflater.class,
-                ViewGroup.class,
-                Bundle.class,
-                new XC_MethodHook() {
-                    @Override
-                    protected void afterHookedMethod(MethodHookParam param) throws Throwable {
-                        XposedBridge.log("afterHookedMethod: HomeFragment.onCreateView");
-                        View viewPager_banner = (View) XposedHelpers.getObjectField(param.thisObject, "viewPager_banner");
-                        ((View) (viewPager_banner.getParent())).setVisibility(View.GONE);
-                        View linearLayout_announcements = (View) XposedHelpers.getObjectField(param.thisObject, "linearLayout_announcements");
-                        linearLayout_announcements.setVisibility(View.GONE);
-                    }
-                });
-        XposedHelpers.findAndHookMethod(
-                "com.picacomic.fregata.adapters.ComicPageRecyclerViewAdapter",
-                lpparam.classLoader,
-                "onCreateViewHolder",
-                ViewGroup.class,
-                int.class,
-                new XC_MethodHook() {
-                    @Override
-                    protected void afterHookedMethod(MethodHookParam param) throws Throwable {
-                        XposedBridge.log("afterHookedMethod: ComicPageRecyclerViewAdapter.onCreateViewHolder");
-                        Object result = param.getResult();
-                        if (!TextUtils.equals(result.getClass().getName(), "com.picacomic.fregata.holders.AdvertisementListViewHolder")) {
-                            return;
-                        }
-                        View webView_ads = (View) XposedHelpers.getObjectField(result, "itemView");
-                        webView_ads.setVisibility(View.GONE);
-                        Object lp = XposedHelpers.newInstance(XposedHelpers.findClass("android.support.v7.widget.RecyclerView$LayoutParams", lpparam.classLoader), 0, 0);
-                        webView_ads.setLayoutParams((ViewGroup.LayoutParams) lp);
-                    }
-                });
-        XposedHelpers.findAndHookMethod("com.picacomic.fregata.adapters.ComicListRecyclerViewAdapter", lpparam.classLoader, "onBindViewHolder", XposedHelpers.findClass("android.support.v7.widget.RecyclerView$ViewHolder", lpparam.classLoader), int.class, new XC_MethodHook() {
-            @Override
-            protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
-                Object viewHolder = param.args[0];
-                if (viewHolder.getClass().getSimpleName().equals("AdvertisementListViewHolder")) {
-                    param.setResult(null);
-                    View itemView = (View) XposedHelpers.getObjectField(viewHolder, "itemView");
-                    ViewGroup.LayoutParams lp = (ViewGroup.LayoutParams) itemView.getLayoutParams();
-                    // 完全隐藏会影响分页加载的逻辑，所以保留一点，
-                    lp.height = 1;
-                    itemView.setLayoutParams(lp);
-                }
+            // 拦截新版WebViewClient (WebResourceRequest) - API 21+
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
+                XposedHelpers.findAndHookMethod(
+                        WebViewClient.class,
+                        "shouldInterceptRequest",
+                        WebView.class,
+                        android.webkit.WebResourceRequest.class,
+                        new XC_MethodHook() {
+                            @Override
+                            protected void beforeHookedMethod(MethodHookParam param) {
+                                Object request = param.args[1];
+                                String url = (String) XposedHelpers.callMethod(request, "getUrl");
+                                if (isAdUrl(url.toString())) {
+                                    param.setResult(createTransparentGifResponse());
+                                }
+                            }
+                        });
             }
-        });
+        } catch (Throwable t) {
+            XposedBridge.log("Hook WebViewClient error: " + t);
+        }
+    }
+
+    /**
+     * 拦截OkHttp网络库中的广告请求
+     */
+    private void hookOkHttp(XC_LoadPackage.LoadPackageParam lpparam) {
+        try {
+            final Class<?> callClass = XposedHelpers.findClass("okhttp3.Call", lpparam.classLoader);
+            final Class<?> requestClass = XposedHelpers.findClass("okhttp3.Request", lpparam.classLoader);
+
+            XposedHelpers.findAndHookMethod(
+                    "okhttp3.internal.http.RealInterceptorChain",
+                    lpparam.classLoader,
+                    "proceed",
+                    requestClass,
+                    new XC_MethodHook() {
+                        @Override
+                        protected void beforeHookedMethod(MethodHookParam param) {
+                            Object request = param.args[0];
+                            String url = (String) XposedHelpers.callMethod(
+                                    XposedHelpers.callMethod(request, "url"),
+                                    "toString");
+
+                            if (isAdUrl(url)) {
+                                // 创建伪造的透明图片响应
+                                Class<?> responseClass = XposedHelpers.findClass("okhttp3.Response", lpparam.classLoader);
+                                Class<?> responseBodyClass = XposedHelpers.findClass("okhttp3.ResponseBody", lpparam.classLoader);
+                                Class<?> mediaTypeClass = XposedHelpers.findClass("okhttp3.MediaType", lpparam.classLoader);
+
+                                // 创建MediaType
+                                Object mediaType = XposedHelpers.callStaticMethod(
+                                        mediaTypeClass,
+                                        "parse",
+                                        "image/gif");
+
+                                // 创建ResponseBody
+                                Object responseBody = XposedHelpers.newInstance(
+                                        responseBodyClass,
+                                        mediaType,
+                                        TRANSPARENT_GIF);
+
+                                // 构建伪造响应
+                                Object response = XposedHelpers.newInstance(
+                                        responseClass,
+                                        request,
+                                        200,  // HTTP 200 OK
+                                        "OK",
+                                        null,  // Handshake
+                                        null,  // Headers
+                                        responseBody,
+                                        null,  // CacheControl
+                                        null,  // SentRequestAtMillis
+                                        null,  // ReceivedResponseAtMillis
+                                        null,  // Exchange
+                                        null   // PriorResponse
+                                );
+
+                                param.setResult(response);
+                            }
+                        }
+                    });
+        } catch (Throwable t) {
+            XposedBridge.log("Hook OkHttp error: " + t);
+        }
+    }
+
+    /**
+     * 创建透明GIF的WebResourceResponse
+     */
+    private WebResourceResponse createTransparentGifResponse() {
+        InputStream inputStream = new ByteArrayInputStream(TRANSPARENT_GIF);
+        return new WebResourceResponse("image/gif", "UTF-8", inputStream);
+    }
+
+    /**
+     * 判断是否为广告域名
+     */
+    private boolean isAdUrl(String url) {
+        return url != null && url.contains("pica-ad-api.diwodiwo.xyz");
     }
 }


### PR DESCRIPTION
内容阅读界面的广告被替换为1px的透明图片，在Hyperos1（安卓14）+哔咔2.2.1.3.3.4可以正常工作
版本号+1可以直接发release了
（之前通过dns屏蔽AD域名的时候会显示占位图片，所以在想是不是替换成透明图片比较好）