### PR TITLE
修复启用“改善闪退测试版”时广告屏蔽失效的问题

### DIFF
--- a/hook/src/main/java/cc/aoeiuv020/hookpicacg/MainHook.java
+++ b/hook/src/main/java/cc/aoeiuv020/hookpicacg/MainHook.java
@@ -7,6 +7,7 @@ import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.BaseAdapter;
 
 import de.robv.android.xposed.IXposedHookLoadPackage;
 import de.robv.android.xposed.XC_MethodHook;
@@ -136,5 +137,36 @@ public class MainHook implements IXposedHookLoadPackage {
                 }
             }
         });
+        XposedHelpers.findAndHookMethod(
+            "com.picacomic.fregata.adapters.a",
+            lpparam.classLoader,
+            "getView",
+            int.class,
+            View.class,
+            ViewGroup.class,
+            new XC_MethodHook() {
+                @Override
+                protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
+                    BaseAdapter adapter = (BaseAdapter) param.thisObject;
+                    int position = (Integer) param.args[0];
+                    int viewType = adapter.getItemViewType(position);
+                    if (viewType == 2) {
+                        ViewGroup parent = (ViewGroup) param.args[2];
+                        Context ctx = parent.getContext();
+                        View convertView = (View) param.args[1];
+                        View emptyView;
+                        // View复用
+                        if (convertView != null && "PICA_AD_KILLER".equals(convertView.getTag())) {
+                            emptyView = convertView; 
+                        } else {
+                            emptyView = new View(ctx);
+                            emptyView.setTag("PICA_AD_KILLER");
+                            // 保留一点，避免影响分页和章节切换
+                            emptyView.setLayoutParams(new android.widget.AbsListView.LayoutParams(1, 1));
+                        }
+                        param.setResult(emptyView);
+                    }
+                }
+            });
     }
 }


### PR DESCRIPTION
这个修复应该可以解决 #3 （仅在PicACG App 2.2.1.3.3.4版本测试通过）

问题原因：
在设置中启用”改善闪退测试版”后阅读页的广告屏蔽完全失效。

启用这个选项之后，会使用另一套阅读器实现，所以先前的Hook完全无效。
在com.picacomic.fregata.activities.ComicViewerActivity的onCreate中：
```
if (e.w(this)) {
    getSupportFragmentManager().beginTransaction().add(R.id.container, new ComicViewerListFragment(), ComicViewerListFragment.TAG).commit();
} else {
    getSupportFragmentManager().beginTransaction().add(R.id.container, new ComicViewFragment(), ComicViewFragment.TAG).commit();
}
```
e.w对应设置中的“改善闪退测试版”开关：
```
public static boolean w(Context context) {
    return context.getSharedPreferences("PICACOMIC_FREGATA", 0).getBoolean("KEY_COMIC_VIEWER_TESTING_VERSION", false);
}
```

说明：
此处试了下如果直接GONE掉和(0, 0)会导致跳下一章的时候出问题，会跳到不正确的页。
但我后面试着又正常了(* ￣︿￣)，不清楚到底什么情况。
保险起见还是用(1, 1)，我看了下视觉效果上没任何区别。
```
// 保留一点，避免影响分页和章节切换
emptyView.setLayoutParams(new android.widget.AbsListView.LayoutParams(1, 1));
```

PS：
我基于您的项目加了一些功能作为我自己项目的配套客户端，该广告屏蔽失效的问题也是我在自己项目使用中发现的。
我已遵循MIT协议要求保留了您项目的版权声明并在README中标注了来源。
感谢您的项目给我带来的帮助(≧∇≦)ﾉ

详见：
https://github.com/Reiyy/PicaBridge
https://github.com/Reiyy/HookMyPica